### PR TITLE
fix Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'remotipart', '~> 1.2'        # fileuploads via ajax
 gem 'zipline'                     # streaming zips on the fly
 
 gem 'whenever'                    # cron tasks
-gem 'nntp-client', git: "git@github.com:matthee/Sapphire-NNTP.git"  # fetching newsgroup posts
+gem 'nntp-client', github: 'matthee/Sapphire-NNTP'  # fetching newsgroup posts
 gem 'mail'                        # fetching, delivering and parsing of emails
 
 gem 'coderay'                     # doing code-highlighting for submission_assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git@github.com:matthee/Sapphire-NNTP.git
+  remote: git://github.com/matthee/Sapphire-NNTP.git
   revision: be75fbe4b70e2d7bec3c7b83df47b5bfe8d36d44
   specs:
     nntp-client (0.0.2)


### PR DESCRIPTION
Ruby 2.1.3, Bundler 1.7.4, rbenv

Something seems to have problems with the syntax.
I changed it to the more readable and cleaner `github` shortcut.

Now I can bundle again!
