### PR TITLE
fix export download with turbolinks

### DIFF
--- a/app/helpers/exports_helper.rb
+++ b/app/helpers/exports_helper.rb
@@ -8,4 +8,8 @@ module ExportsHelper
 
     render template, f: form_builder, export: export
   end
+
+  def download_link_title(export)
+    foundation_icon(:download) + " download (#{number_to_human_size File.size(export.file.to_s)})"
+  end
 end

--- a/app/views/exports/index.html.erb
+++ b/app/views/exports/index.html.erb
@@ -26,8 +26,15 @@
         <td><%= l export.created_at, format: :short %></td>
         <td class='text-right'>
           <% if export.finished? %>
-            <%= link_to foundation_icon(:download) + " download (#{number_to_human_size File.size(export.file.to_s)})", download_term_export_path(current_term, export),class: "small button" %>
-            <%= link_to "delete", term_export_path(current_term, export), class: "small alert button", method: :delete, data: {confirm: "Are you sure?"} %>
+            <%= link_to download_link_title(export),
+              download_term_export_path(current_term, export),
+              class: "small button",
+              data: { "data-no-turbolink" => "true" } %>
+
+            <%= link_to "delete", term_export_path(current_term, export),
+              class: "small alert button",
+              method: :delete,
+              data: {confirm: "Are you sure?"} %>
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
we need to tell turbolinks that this is a download-only link,
otherwise it tries applying turbolinks-magic - which fails.

fixes #151
