### PR TITLE
do not regenerate binstubs on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,3 +11,5 @@ set :linked_files, %w{config/database.yml config/mail.yml}
 set :linked_dirs, %w{bin log emails uploads persistent tmp/pids}
 
 set :log_level, :debug
+
+set :bundle_binstubs, nil


### PR DESCRIPTION
This removes the nasty warning about wrong binstubs.
Binstubs must be checked into version control.
Binstubs must not be regenerated during deployment.
