### PR TITLE
Next and Previous Buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem 'cocoon'                      # for nested upload forms
 gem 'sidekiq'                     # async jobs in background, used for imports
 gem 'sinatra', '>= 1.3.0', :require => nil    # small rack framework, used for sidekiq ui
 
+gem 'proximal_records'            # providing next and previous record functionality, used for single evaluations
+
 group :production do
   gem 'therubyracer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,7 @@ GEM
     polyamorous (0.6.4)
       activerecord (>= 3.0)
     polyglot (0.3.5)
+    proximal_records (0.0.2)
     pry (0.10.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -458,6 +459,7 @@ DEPENDENCIES
   nokogiri
   pg
   poltergeist
+  proximal_records
   pry
   pry-byebug
   pry-doc

--- a/app/controllers/single_evaluations_controller.rb
+++ b/app/controllers/single_evaluations_controller.rb
@@ -15,11 +15,10 @@ class SingleEvaluationsController < ApplicationController
 
     submission_scope = SubmissionScopingService.new(params, @tutorial_group).scoped_submissions(Submission.for_exercise(@submission.exercise))
 
-    @previous_submission = submission_scope.next(@submission, :submitted_at)
-    @next_submission = submission_scope.previous(@submission, :submitted_at)
+    @previous_submission, @next_submission = @submission.proximal_records(submission_scope)
 
     @exercise = @submission.exercise
-    @evaluation_groups = @submission.submission_evaluation.evaluation_groups.includes([:rating_group, {evaluations: :rating}]).order{rating_group.ratings.row_order.asc}.order{rating_group.row_order.asc}
+    @evaluation_groups = @submission.submission_evaluation.evaluation_groups.includes([:rating_group, {evaluations: :rating}]).references(:all).order{rating_group.ratings.row_order.asc}.order{rating_group.row_order.asc}
     @term = @exercise.term
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,6 @@
 class Submission < ActiveRecord::Base
+  include ProximalRecords
+
   attr_accessor :student_group_id
 
   belongs_to :exercise
@@ -29,14 +31,6 @@ class Submission < ActiveRecord::Base
   after_create :create_submission_evaluation
 
   accepts_nested_attributes_for :submission_assets, allow_destroy: true, reject_if: :all_blank
-
-  def self.next(submission, order = :id)
-    Submission.where{submissions.send(my {order}) > submission.send(order)}.order(:id).order(order => :asc).first
-  end
-
-  def self.previous(submission, order = :id)
-    Submission.where{submissions.send(my {order}) < submission.send(order)}.order(:id).order(order => :desc).first
-  end
 
   def assign_to(student_group)
     self.student_group_registration = student_group.register_for(self.exercise)


### PR DESCRIPTION
Added `proximal_records` do determine previous and next records.

Should fix issues with next and previous buttons once and for all.

**Breaks sqlite support**
