### PR TITLE
Replace policy-record-struct wrappers with DSL

### DIFF
--- a/app/controllers/email_addresses_controller.rb
+++ b/app/controllers/email_addresses_controller.rb
@@ -3,27 +3,23 @@ class EmailAddressesController < ApplicationController
 
   before_action :fetch_email_address, only: [:edit, :update, :destroy]
 
-  class EmailAddressPolicyRecord < Struct.new(:account)
-    def policy_class
-      EmailAddressPolicy
-    end
-  end
-
   def index
-    authorize EmailAddressPolicyRecord.new(account)
+    authorize EmailAddressPolicy.with account
     @email_addresses = account.email_addresses
   end
 
   def new
     @email_address = EmailAddress.new
-    @email_address.account = account
     authorize @email_address
+
+    @email_address.account = account
   end
 
   def create
     @email_address = EmailAddress.new(email_params)
-    @email_address.account = account
     authorize @email_address
+
+    @email_address.account = account
 
     if @email_address.save
       redirect_to account_email_addresses_path(account), notice: "Added #{@email_address.email} to this account"

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,13 +1,11 @@
 class ExercisesController < ApplicationController
   before_action :set_context, only: [:edit, :update, :destroy]
 
-  skip_after_action :verify_authorized, only: :index
-
   def index
     @term = Term.find(params[:term_id])
-    @exercises = @term.exercises
+    authorize ExercisePolicy.with @term
 
-    raise Pundit::NotAuthorizedError unless ExercisePolicy.new(pundit_user, @term).index?
+    @exercises = @term.exercises
   end
 
   def new
@@ -19,6 +17,7 @@ class ExercisesController < ApplicationController
   def create
     @exercise = Exercise.new(exercise_params)
     authorize @exercise
+
     @exercise.row_order_position = :last
     @term = @exercise.term
 
@@ -49,8 +48,9 @@ class ExercisesController < ApplicationController
 
   def set_context
     @exercise = Exercise.find(params[:id] || params[:exercise_id])
-    @term = @exercise.term
     authorize @exercise
+
+    @term = @exercise.term
   end
 
   def exercise_params

--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -1,17 +1,11 @@
 class ExportsController < ApplicationController
   include TermContext
 
-  class ExportPolicyRecord < Struct.new(:term)
-    def policy_class
-      ExportPolicy
-    end
-  end
-
-  before_action :fetch_export, only: [:show, :download, :destroy]
+  before_action :fetch_export, only: [:download, :destroy]
 
   def index
     @exports = current_term.exports.order(created_at: :desc)
-    authorize ExportPolicyRecord.new(current_term)
+    authorize ExportPolicy.with current_term
   end
 
   def new
@@ -21,12 +15,12 @@ class ExportsController < ApplicationController
       @export.term = current_term
       authorize @export
     else
-      authorize ExportPolicyRecord.new(current_term)
+      authorize ExportPolicy.with current_term
     end
   end
 
   def create
-    authorize ExportPolicyRecord.new(current_term)
+    authorize ExportPolicy.with current_term
 
     @export_type = params[:type]
     if Export.valid_type?(@export_type) && @export = Export.new_from_type(@export_type, export_params)

--- a/app/controllers/grading_reviews_controller.rb
+++ b/app/controllers/grading_reviews_controller.rb
@@ -1,20 +1,14 @@
 class GradingReviewsController < ApplicationController
   include TermContext
 
-  class GradingReviewPolicyRecord < Struct.new(:user, :term)
-    def policy_class
-      GradingReviewPolicy
-    end
-  end
-
   def index
-    authorize GradingReviewPolicyRecord.new(current_account, current_term)
+    authorize GradingReviewPolicy.with current_term
 
     @term_registrations = current_term.term_registrations.students.search(params[:q]).load if params[:q].present?
   end
 
   def show
-    authorize GradingReviewPolicyRecord.new(current_account, current_term)
+    authorize GradingReviewPolicy.with current_term
 
     @student_registration = current_term.term_registrations.students.find(params[:id])
     @student = @student_registration.account

--- a/app/controllers/grading_scales_controller.rb
+++ b/app/controllers/grading_scales_controller.rb
@@ -1,10 +1,4 @@
 class GradingScalesController < ApplicationController
-  GradingScalePolicyRecord = Struct.new :term do
-    def policy_class
-      GradingScalePolicy
-    end
-  end
-
   before_action :fetch_term, only: [:edit, :update]
 
   def edit
@@ -19,7 +13,7 @@ class GradingScalesController < ApplicationController
   private
   def fetch_term
     @term = Term.find(params[:term_id])
-    authorize GradingScalePolicyRecord.new(@term)
+    authorize GradingScalePolicy.with @term
   end
 
   def term_params

--- a/app/controllers/result_publications_controller.rb
+++ b/app/controllers/result_publications_controller.rb
@@ -1,9 +1,9 @@
 class ResultPublicationsController < ApplicationController
-  skip_after_action :verify_authorized, only: :index
-
   before_action :set_context
 
   def index
+    authorize ResultPublication
+
     @result_publications = @exercise.result_publications
       .joins(:tutorial_group)
       .includes(tutorial_group: {tutor_term_registrations: :account})

--- a/app/controllers/single_evaluations_controller.rb
+++ b/app/controllers/single_evaluations_controller.rb
@@ -1,15 +1,9 @@
 class SingleEvaluationsController < ApplicationController
   include ScopingHelpers
 
-  SingleEvaluationPolicyRecord = Struct.new :submission do
-    def policy_class
-      SingleEvaluationPolicy
-    end
-  end
-
   def show
     @submission = Submission.find(params[:id])
-    authorize SingleEvaluationPolicyRecord.new @submission
+    authorize SingleEvaluationPolicy.with @submission
 
     @term = @submission.exercise.term
     @tutorial_group = current_tutorial_group(@term)
@@ -32,7 +26,7 @@ class SingleEvaluationsController < ApplicationController
   def update
     @evaluation = Evaluation.find(params[:id])
     @submission = @evaluation.submission
-    authorize SingleEvaluationPolicyRecord.new @submission
+    authorize SingleEvaluationPolicy.with @submission
 
     @rating = @evaluation.rating
 

--- a/app/controllers/staff_controller.rb
+++ b/app/controllers/staff_controller.rb
@@ -1,24 +1,19 @@
 class StaffController < ApplicationController
   include TermContext
 
-  class StaffPolicyRecord < Struct.new(:user, :term)
-    def policy_class
-      StaffPolicy
-    end
-  end
-
   before_action :setup_form_context, only: [:new, :create]
 
   def index
     @term_registrations = current_term.term_registrations.staff.ordered_by_name
-    authorize StaffPolicyRecord.new(current_account, current_term)
+    authorize StaffPolicy.with current_term
   end
 
   def new
     @term_registration = TermRegistration.new
+    authorize @term_registration
+
     @term_registration.term = current_term
     @term_registration.role = Roles::LECTURER
-    authorize @term_registration
   end
 
   def create
@@ -41,18 +36,17 @@ class StaffController < ApplicationController
   end
 
   def search
+    authorize StaffPolicy.with current_term
+
     @accounts = Account.search(params[:q]).limit(100)
     @search_terms = params[:q]
-    authorize StaffPolicyRecord.new(current_account, current_term)
   end
 
   private
   def term_registration_params
-    if params[:term_registration] && params[:term_registration][:role] == Roles::LECTURER
-      params.require(:term_registration).permit(:account_id, :role)
-    elsif params[:term_registration] && params[:term_registration][:role] == Roles::TUTOR
-      params.require(:term_registration).permit(:account_id, :role, :tutorial_group_id)
-    end
+    permitted_params = [:account_id, :role]
+    permitted_params << :tutorial_group_id if params[:term_registration][:role] == Roles::TUTOR
+    params.require(:term_registration).permit permitted_params
   end
 
   def setup_form_context

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,32 +1,24 @@
 class StudentsController < ApplicationController
   include TermContext
 
-  before_action :fetch_student, only: [:show]
-
-  class StudentsPolicyRecord < Struct.new(:user, :term)
-    def policy_class
-      StudentsPolicy
-    end
-  end
-
   def index
-    authorize StudentsPolicyRecord.new(current_account, current_term)
+    authorize StudentsPolicy.with current_term
+
     @term_registrations = students_scope.includes(:account, :exercise_registrations, :tutorial_group, :term)
     @grading_scale = GradingScaleService.new(current_term, @term_registrations)
   end
 
   def show
-    authorize StudentsPolicyRecord.new(current_account, current_term)
+    authorize StudentsPolicy.with current_term
+
+    @term_registration = students_scope.find(params[:id])
     @exercise_registrations = @term_registration.exercise_registrations.ordered_by_exercise.includes(:exercise).load
     @grading_scale = GradingScaleService.new(current_term, [@term_registration])
   end
 
   private
+
   def students_scope
     current_term.term_registrations.students
-  end
-
-  def fetch_student
-    @term_registration = students_scope.find(params[:id])
   end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -8,11 +8,13 @@ class AccountPolicy < PunditBasePolicy
   end
 
   def edit?
-    user.admin? || user == record
+    user.admin? ||
+    user == record
   end
 
   def update?
-    user.admin? || user == record
+    user.admin? ||
+    user == record
   end
 
   def destroy?
@@ -20,10 +22,12 @@ class AccountPolicy < PunditBasePolicy
   end
 
   def change_password?
-    user.admin? || user == record
+    user.admin? ||
+    user == record
   end
 
   def update_password?
-    user.admin? || user == record
+    user.admin? ||
+    user == record
   end
 end

--- a/app/policies/email_address_policy.rb
+++ b/app/policies/email_address_policy.rb
@@ -1,30 +1,30 @@
 class EmailAddressPolicy < PunditBasePolicy
   def index?
-    permitted?
+    user.admin? ||
+    user == record
   end
 
   def new?
-    create?
+    user.admin? ||
+    user == record.account
   end
 
   def create?
-    permitted?
+    user.admin? ||
+    user == record.account
   end
 
   def edit?
-    update?
+    user.admin? ||
+    user == record.account
   end
 
   def update?
-    permitted?
+    user.admin? ||
+    user == record.account
   end
 
   def destroy?
-    permitted?
-  end
-
-  private
-  def permitted?
     user.admin? ||
     user == record.account
   end

--- a/app/policies/exercise_policy.rb
+++ b/app/policies/exercise_policy.rb
@@ -1,10 +1,12 @@
 class ExercisePolicy < PunditBasePolicy
   def index?
-    user.admin? || record.associated_with?(user)
+    user.admin? ||
+    record.associated_with?(user)
   end
 
   def show?
-    user.admin? || record.term.associated_with?(user)
+    user.admin? ||
+    record.term.associated_with?(user)
   end
 
   def new?

--- a/app/policies/export_policy.rb
+++ b/app/policies/export_policy.rb
@@ -1,6 +1,6 @@
 class ExportPolicy < PunditBasePolicy
   def index?
-    authorized?
+    authorized? record
   end
 
   def show?
@@ -8,15 +8,15 @@ class ExportPolicy < PunditBasePolicy
   end
 
   def new?
-    authorized?
+    authorized? record
   end
 
   def create?
-    authorized?
+    authorized? record
   end
 
   def download?
-    show?
+    authorized?
   end
 
   def destroy?
@@ -24,7 +24,8 @@ class ExportPolicy < PunditBasePolicy
   end
 
   private
-  def authorized?
-    user.admin? || user.lecturer_of_term?(record.term)
+
+  def authorized?(r = nil)
+    user.admin? || user.lecturer_of_term?(r || record.term)
   end
 end

--- a/app/policies/grading_review_policy.rb
+++ b/app/policies/grading_review_policy.rb
@@ -1,11 +1,11 @@
 class GradingReviewPolicy < PunditBasePolicy
   def index?
     user.admin? ||
-    user.staff_of_term?(record.term)
+    user.staff_of_term?(record)
   end
 
   def show?
     user.admin? ||
-    user.staff_of_term?(record.term)
+    user.staff_of_term?(record)
   end
 end

--- a/app/policies/grading_scale_policy.rb
+++ b/app/policies/grading_scale_policy.rb
@@ -1,9 +1,11 @@
 class GradingScalePolicy < PunditBasePolicy
   def edit?
-    update?
+    user.admin? ||
+    user.lecturer_of_term?(record)
   end
 
   def update?
-    user.admin? || user.lecturer_of_term?(record.term)
+    user.admin? ||
+    user.lecturer_of_term?(record)
   end
 end

--- a/app/policies/pundit_base_policy.rb
+++ b/app/policies/pundit_base_policy.rb
@@ -13,4 +13,16 @@ class PunditBasePolicy
     @user = user
     @record = record
   end
+
+  def self.with(record)
+    klass = self
+    record.define_singleton_method(:policy_class) do
+      # remove monkey-patched method
+      # so that any further policy query (in a view) returns the original policy
+      self.singleton_class.send :undef_method, :policy_class
+
+      klass
+    end
+    record
+  end
 end

--- a/app/policies/service_policy.rb
+++ b/app/policies/service_policy.rb
@@ -1,21 +1,16 @@
 class ServicePolicy < PunditBasePolicy
   def index?
-    authorized?
-  end
-
-  def edit?
-    update?
-  end
-
-  def update?
-    authorized?
-  end
-
-  private
-
-  def authorized?
     user.admin? ||
     user.lecturer_of_term?(record.term)
   end
 
+  def edit?
+    user.admin? ||
+    user.lecturer_of_term?(record.term)
+  end
+
+  def update?
+    user.admin? ||
+    user.lecturer_of_term?(record.term)
+  end
 end

--- a/app/policies/staff_policy.rb
+++ b/app/policies/staff_policy.rb
@@ -1,13 +1,16 @@
 class StaffPolicy < PunditBasePolicy
   def index?
-    user.admin? || user.staff_of_term?(record.term)
+    user.admin? ||
+    user.staff_of_term?(record)
   end
 
   def new?
-    user.admin? || user.lecturer_of_term?(record.term)
+    user.admin? ||
+    user.lecturer_of_term?(record.term)
   end
 
   def search?
-    new?
+    user.admin? ||
+    user.lecturer_of_term?(record)
   end
 end

--- a/app/policies/student_results_policy.rb
+++ b/app/policies/student_results_policy.rb
@@ -1,6 +1,7 @@
 class StudentResultsPolicy < PunditBasePolicy
   def index?
-    user.admin? || user.student_of_term?(record.subject)
+    user.admin? ||
+    user.student_of_term?(record.subject)
   end
 
   def show?

--- a/app/policies/students_policy.rb
+++ b/app/policies/students_policy.rb
@@ -1,9 +1,11 @@
 class StudentsPolicy < PunditBasePolicy
   def index?
-    user.admin? || user.staff_of_term?(record.term)
+    user.admin? ||
+    user.staff_of_term?(record.term)
   end
 
   def show?
-    user.admin? || user.staff_of_term?(record.term)
+    user.admin? ||
+    user.staff_of_term?(record.term)
   end
 end

--- a/app/policies/term_policy.rb
+++ b/app/policies/term_policy.rb
@@ -18,12 +18,12 @@ class TermPolicy < PunditBasePolicy
   end
 
   def edit?
-    @edit ||= user.admin? ||
+    user.admin? ||
     user.lecturer_of_term?(record)
   end
 
   def update?
-    @edit ||= user.admin? ||
+    user.admin? ||
     user.lecturer_of_term?(record)
   end
 

--- a/app/policies/term_registration_policy.rb
+++ b/app/policies/term_registration_policy.rb
@@ -1,6 +1,6 @@
 class TermRegistrationPolicy < PunditBasePolicy
   def new?
-    create?
+    user.admin? || user.lecturer_of_term?(record.term)
   end
 
   def create?

--- a/app/views/terms/_sidebar.html.erb
+++ b/app/views/terms/_sidebar.html.erb
@@ -14,8 +14,7 @@
     <%= sidenav_item(:megaphone, "Results", term_results_path(@term)) %>
   <% end %>
 
-
-  <% if policy(term).update? %>
+  <% if policy(@term).update? %>
     <li class='divider'></li>
     <%= sidenav_item(:pencil, "Administrate", edit_term_path(term), term_sidebar_administrative_active?) %>
   <% end %>

--- a/spec/policies/grading_scale_policy_spec.rb
+++ b/spec/policies/grading_scale_policy_spec.rb
@@ -1,19 +1,11 @@
 require 'rails_helper'
 
 describe GradingScalePolicy do
-  let(:term_policy_record) do
-    Struct.new :term do
-      def policy_class
-        GradingScalePolicy
-      end
-    end
-  end
-
-  subject { Pundit.policy(user, term_policy_record.new(term)) }
+  subject { Pundit.policy(user, GradingScalePolicy.with(record)) }
 
   context 'as an admin' do
     let(:user) { FactoryGirl.create(:account, :admin) }
-    let(:term) { FactoryGirl.create(:term) }
+    let(:record) { FactoryGirl.create(:term) }
 
     it { is_expected.to permit_authorization :edit }
     it { is_expected.to permit_authorization :update }
@@ -21,7 +13,7 @@ describe GradingScalePolicy do
 
   context 'as a lecturer' do
     let(:user) { FactoryGirl.create(:account, :lecturer) }
-    let(:term) { user.term_registrations.lecturers.first.term }
+    let(:record) { user.term_registrations.lecturers.first.term }
 
     it { is_expected.to permit_authorization :edit }
     it { is_expected.to permit_authorization :update }
@@ -29,7 +21,7 @@ describe GradingScalePolicy do
 
   context 'as a tutor' do
     let(:user) { FactoryGirl.create(:account, :tutor) }
-    let(:term) { user.term_registrations.tutors.first.term }
+    let(:record) { user.term_registrations.tutors.first.term }
 
     it { is_expected.not_to permit_authorization :edit }
     it { is_expected.not_to permit_authorization :update }
@@ -37,7 +29,7 @@ describe GradingScalePolicy do
 
   context 'as a student' do
     let(:user) { FactoryGirl.create(:account, :student) }
-    let(:term) { user.term_registrations.students.first.term }
+    let(:record) { user.term_registrations.students.first.term }
 
     it { is_expected.not_to permit_authorization :edit }
     it { is_expected.not_to permit_authorization :update }


### PR DESCRIPTION
request for comments:

This could replace the custom structs used to force a different policy class onto a record for authentication.
Simplifies it by directly invoking the desired policy for authentication purposes.

What do you think - is this a valuable alternative?
Or are you more comfortable/happier with the `*PolicyRecord` struct wrapper?

fixes #195
