### PR TITLE
fix import_options enum

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -12,7 +12,7 @@ class ImportsController < ApplicationController
     @import.term = @term
     @import.build_import_options
 
-    @import.import_options.matching_groups = :both if @term.group_submissions?
+    @import.import_options.matching_groups = :both_matches if @term.group_submissions?
 
     authorize @import
   end

--- a/app/models/import_options.rb
+++ b/app/models/import_options.rb
@@ -3,12 +3,12 @@ class ImportOptions < ActiveRecord::Base
 
   belongs_to :import
 
-  enum matching_groups: [:first, :both]
+  enum matching_groups: [:first_match, :both_matches]
 
   validates :import, presence: true
 
   after_initialize do
-    self.matching_groups        ||= :first
+    self.matching_groups        ||= :first_match
     self.tutorial_groups_regexp ||= '\AT(?<tutorial>[\d]+)\z'
     self.student_groups_regexp  ||= '\AG(?<tutorial>[\d]+)-(?<student>[\d]+)\z'
     self.headers_on_first_line  ||= true

--- a/app/views/imports/_form.html.erb
+++ b/app/views/imports/_form.html.erb
@@ -37,8 +37,8 @@
               </div>
               <div class="row">
                 <div class='large-12 large-centered text-center'>
-                  <%= ff.radio_button :matching_groups, "first",
-                    checked: @import.import_options.matching_groups == "first" %>
+                  <%= ff.radio_button :matching_groups, "first_match",
+                    checked: @import.import_options.matching_groups == "first_match" %>
                 </div>
               </div>
               <div class="row">
@@ -53,8 +53,8 @@
               </div>
               <div class="row">
                 <div class='large-12 large-centered text-center'>
-                  <%= ff.radio_button :matching_groups, "both",
-                    checked: @import.import_options.matching_groups == "both"  %>
+                  <%= ff.radio_button :matching_groups, "both_matches",
+                    checked: @import.import_options.matching_groups == "both_matches"  %>
                 </div>
               </div>
               <div class="row">

--- a/lib/import/importer.rb
+++ b/lib/import/importer.rb
@@ -52,13 +52,13 @@ module Import::Importer
       student_group_title = []
 
       case import_options.matching_groups.to_sym
-      when :first
+      when :first_match
         regexp = Regexp.new import_options.tutorial_groups_regexp
         m = regexp.match group_title
 
         tutorial_group = create_tutorial_group "T#{m[:tutorial]}"
         create_term_registration row, account, tutorial_group
-      when :both
+      when :both_matches
         regexp = Regexp.new import_options.student_groups_regexp
         m = regexp.match group_title
 

--- a/spec/controllers/imports_controller_spec.rb
+++ b/spec/controllers/imports_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ImportsController do
         term_id: term.id,
         file: Rack::Test::UploadedFile.new(prepare_static_test_file('import_data.csv'), 'text/csv'),
         import_options_attributes: {
-          matching_groups: 'first',
+          matching_groups: 'first_match',
           tutorial_groups_regexp: "\\AT(?<tutorial>[\\d]+)\\z",
           headers_on_first_line: '1',
           column_separator: ';',


### PR DESCRIPTION
A enum value is not allowed to be named like an existing method in that class.

Rails 4.2 introduces an error messages which describes this problem.
This is a backport of the fix.
