### PR TITLE
kill therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,10 +48,6 @@ gem 'sinatra', '>= 1.3.0', :require => nil    # small rack framework, used for s
 gem 'writeexcel'                  # exporting excel spreadsheets
 gem 'multi_logger'                # custom log files
 
-group :production do
-  gem 'therubyracer'
-end
-
 group :development do
   gem 'guard'
   gem 'guard-bundler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,6 @@ GEM
     letter_opener_web (1.2.3)
       letter_opener (~> 1.0)
       rails (>= 3.2)
-    libv8 (3.16.14.3)
     listen (2.8.3)
       celluloid (>= 0.15.2)
       rb-fsevent (>= 0.9.3)
@@ -308,7 +307,6 @@ GEM
     redis (3.1.0)
     redis-namespace (1.5.1)
       redis (~> 3.0, >= 3.0.4)
-    ref (1.0.5)
     remotipart (1.2.1)
     request_store (1.1.0)
     rspec (3.1.0)
@@ -386,9 +384,6 @@ GEM
       net-ssh (>= 2.8.0)
     terminal-notifier (1.6.2)
     terminal-notifier-guard (1.6.4)
-    therubyracer (0.12.1)
-      libv8 (~> 3.16.14.0)
-      ref
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0)
@@ -504,7 +499,6 @@ DEPENDENCIES
   squeel (~> 1.1)
   terminal-notifier
   terminal-notifier-guard
-  therubyracer
   thin
   traceroute
   turbolinks

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This project is intended to be used to evaluate students during a course-term ba
     - sqlite3 (only basic support, no background jobs)
 * Redis
 * Sidekiq
+* Node.js
+    - on the server for assets precompilation
+    - make sure it is part of PATH
+    - v0.10.35 or above
 * working SMTP server for email delivery
 
 ## Contributors

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,3 +13,7 @@ set :linked_dirs, %w{log uploads persistent tmp/pids}
 set :log_level, :info
 
 set :bundle_binstubs, nil
+
+set :default_env, {
+  'PATH' => 'PATH=$PATH:/home/sapphire/bin'
+}


### PR DESCRIPTION
It uses a lot of resources and is not really needed.
- remove this gem 
- install NVM on the target server
- install node.js on the target server
- set the PATH to include the new node.js binary

closes #223
fixes #225 

Assets pre compilation works fine.
Servers are aware of node binary through a symlink: 
`/home/sapphire/bin/node` -> `/home/sapphire/.nvm/v0.10.35/bin/node`

(apparently `/home/sapphire/bin` is already in the `$PATH` for unknown reasons)

Staging server runs fine - this branch is already deployed there.
