### PR TITLE
Use sidekiq namespace

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { :namespace => 'Sapphire'}
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { :namespace => 'Sapphire' }
+end


### PR DESCRIPTION
Using a separate namespace is beneficial for development, when more than one project uses redis in order to store sidekiq jobs. Additionally it's also possible, to host more than one project using sidekiq/redis in production.
