### PR TITLE
Sidekiq: added 'mailers' queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,3 +2,6 @@
 :pidfile: ./tmp/pids/sidekiq.pid
 :logfile: ./log/sidekiq.log
 :concurrency: 25
+:queues:
+  - default
+  - mailers


### PR DESCRIPTION
Rails internally uses the `mailers` queue to deliver delayed emails - this needs to be added to sidekiq as well, as it won't process those jobs otherwise.
