### PR TITLE
send emails to admins on exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'sinatra', '>= 1.3.0', require: false    # small rack framework, used for si
 gem 'writeexcel'                  # exporting excel spreadsheets
 gem 'multi_logger'                # custom log files
 
+gem 'exception_notification'      # send out emails if an unhandled exception occours
+
 group :development, :test do
   gem 'pry'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,9 @@ GEM
       activemodel
     erubis (2.7.0)
     eventmachine (1.0.7)
+    exception_notification (4.1.0)
+      actionmailer (>= 3.0.4)
+      activesupport (>= 3.0.4)
     execjs (2.5.2)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -512,6 +515,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 3.2)
   email_validator
+  exception_notification
   factory_girl_rails
   flash_render
   foundation-icons-sass-rails (~> 3.0)

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,27 @@
+require 'exception_notification/rails'
+require 'exception_notification/sidekiq'
+
+ExceptionNotification.configure do |config|
+  # Ignore additional exception types.
+  # ActiveRecord::RecordNotFound, AbstractController::ActionNotFound and ActionController::RoutingError are already added.
+  # config.ignored_exceptions += %w{ActionView::TemplateError CustomError}
+
+  # Adds a condition to decide when an exception must be ignored or not.
+  # The ignore_if method can be invoked multiple times to add extra conditions.
+  config.ignore_if do |exception, options|
+    not Rails.env.production?
+  end
+
+  recipients = begin
+    Account.admins.pluck(:email)
+  rescue
+    ['sapphire@iicm.edu']
+  end
+
+  # Email notifier sends notifications by email.
+  config.add_notifier :email, {
+    email_prefix:         '[Sapphire ERROR] ',
+    sender_address:       %{"Sapphire Exception Notifier" <sapphire@iicm.edu>},
+    exception_recipients: recipients
+  }
+end


### PR DESCRIPTION
some default exceptions are already ignored

List of email recipients seems to be only configurable once.
So if we add a new admin member - it won't get new emails until we restart Rails (AFAIK)
Right now travis fails because of this - so we need to find a nifty way to set the recipient list.
