### PR TITLE
fix encoding in zip filenames

### DIFF
--- a/app/helpers/student_submissions_helper.rb
+++ b/app/helpers/student_submissions_helper.rb
@@ -1,4 +1,5 @@
 require 'zip'
+require 'base64'
 
 module StudentSubmissionsHelper
   def extract_filelist(archive)
@@ -6,7 +7,9 @@ module StudentSubmissionsHelper
     Zip::File.open(archive) do |zip_file|
       zip_file.each do |entry|
         if SubmissionAsset::EXCLUDED_FILTER.map { |e| entry.name !~ e }.all?
-          filelist << [entry.name, entry.size]
+          id = Base64.encode64(entry.name).strip
+          filename = entry.name.force_encoding('utf-8')
+          filelist << { id: id, filename: filename, size: entry.size }
         end
       end
     end

--- a/app/views/student_submissions/catalog.html.erb
+++ b/app/views/student_submissions/catalog.html.erb
@@ -14,9 +14,10 @@ will be submitted for <%= @exercise.title %>:
       <%= fields_for "submission_assets[#{archive.id}]" do |archive_form| %>
         <% extract_filelist(archive.file.to_s).each_with_index do |entry, index| %>
           <%= archive_form.fields_for "file_#{index}" do |file_form| %>
-            <%= hidden_field_tag "#{file_form.object_name}[full_path]", entry.first %>
+            <%= hidden_field_tag "#{file_form.object_name}[id]", entry[:id] %>
+            <%= hidden_field_tag "#{file_form.object_name}[full_path]", entry[:filename] %>
             <%= file_form.label "extract" do %>
-              <%= file_form.check_box "extract" %> <%= entry.first %> (<%= entry.last %> bytes)
+              <%= file_form.check_box "extract" %> <%= entry[:filename] %> (<%= entry[:size] %> bytes)
             <% end %>
           <% end %>
         <% end %>

--- a/spec/controllers/student_submissions_controller_spec.rb
+++ b/spec/controllers/student_submissions_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'base64'
 
 RSpec.describe StudentSubmissionsController do
   render_views
@@ -245,6 +246,14 @@ RSpec.describe StudentSubmissionsController do
     let!(:submission) { FactoryGirl.create :submission, exercise: exercise, submitter: @current_account }
     let!(:exercise_registration) { FactoryGirl.create :exercise_registration, exercise: exercise, term_registration: term_registration, submission: submission }
 
+    def file_extraction_params(file, extract = '1')
+      {
+        id: Base64.encode64(file),
+        full_path: file,
+        extract: extract,
+      }
+    end
+
     it 'extracts the checked files' do
       sa = submission.submission_assets.create file: prepare_static_test_file('submission_nested_archives.zip')
 
@@ -252,10 +261,10 @@ RSpec.describe StudentSubmissionsController do
         exercise_id: exercise.id,
         submission_assets: {
           sa.id.to_s => {
-            "file_0" => { full_path: 'simple_submission.txt', extract: '1' },
-            "file_1" => { full_path: 'import_data.csv', extract: '1' },
-            "file_2" => { full_path: 'some_folder/submission.zip', extract: '1' },
-            "file_3" => { full_path: 'some_other_folder/some_dir/import_data_invalid_parsing.csv', extract: '1' },
+            "file_0" => file_extraction_params('simple_submission.txt'),
+            "file_1" => file_extraction_params('import_data.csv'),
+            "file_2" => file_extraction_params('some_folder/submission.zip'),
+            "file_3" => file_extraction_params('some_other_folder/some_dir/import_data_invalid_parsing.csv'),
           }
         }
       }
@@ -286,9 +295,9 @@ RSpec.describe StudentSubmissionsController do
         exercise_id: exercise.id,
         submission_assets: {
           sa.id.to_s => {
-            "file_0" => { full_path: 'simple_submission.txt', extract: '1' },
-            "file_1" => { full_path: '.DS_Store', extract: '1' },
-            "file_2" => { full_path: '.git/config', extract: '1' },
+            "file_0" => file_extraction_params('simple_submission.txt'),
+            "file_1" => file_extraction_params('.DS_Store',),
+            "file_2" => file_extraction_params('.git/config'),
           }
         }
       }
@@ -312,7 +321,7 @@ RSpec.describe StudentSubmissionsController do
         exercise_id: exercise.id,
         submission_assets: {
           sa.id.to_s => {
-            "file_0" => { full_path: 'simple_submission.txt', extract: '1' },
+            "file_0" => file_extraction_params('simple_submission.txt'),
           }
         }
       }


### PR DESCRIPTION
fixes #288 

This PR forces UTF-8 filename encoding for ZIP extractions.

Windows seems to mess up the ZIP archive with invalid filename encodings.
See: https://github.com/rubyzip/rubyzip/wiki/Files-with-non-ascii-filenames
and https://github.com/rubyzip/rubyzip/issues/84
