### PR TITLE
Enhancing SingleEvaluationsController Spec

### DIFF
--- a/spec/controllers/single_evaluations_controller_spec.rb
+++ b/spec/controllers/single_evaluations_controller_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe SingleEvaluationsController do
         sign_in(tutor_registration.account)
         get :show, id: submission.id
         expect(response).to have_http_status(:success)
+        expect(response.body).to have_content('Submission containing special chars')
       end
 
     end


### PR DESCRIPTION
Testing if the submission is actually rendered, instead of showing "Cannot display inline version of this asset"
