### PR TITLE
Refactor export job to use global-id instead of plain record id

### DIFF
--- a/app/controllers/exports_controller.rb
+++ b/app/controllers/exports_controller.rb
@@ -27,7 +27,7 @@ class ExportsController < ApplicationController
       @export.term = current_term
 
       if @export.save
-        ExportJob.perform_later @export.id
+        ExportJob.perform_later @export
 
         redirect_to term_exports_path(current_term), notice: 'Export has been started, you will be notified when it is finished'
       else

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,8 +1,7 @@
 class ExportJob < ActiveJob::Base
   queue_as :default
 
-  def perform(export_id)
-    export = Export.find(export_id)
+  def perform(export)
     export.perform_export!
 
     NotificationJob.export_finished_notifications(export)


### PR DESCRIPTION
Minor refactoring, let rails take care of serializing the record.
