### PR TITLE
Update to capistrano 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,7 @@ group :development do
   gem 'capistrano-rvm'         # capistrano plugin for RVM
   gem 'capistrano-rails'       # capistrano plugin for Rails
   gem 'capistrano-sidekiq'     # capistrano plugin for Sidekiq
-  gem 'capistrano-passenger'   # capistrano plugin for Passenger
+  gem 'capistrano-passenger', '0.0.5'# capistrano plugin for Passenger
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,7 +72,7 @@ GEM
     capistrano-bundler (1.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
-    capistrano-passenger (0.2.0)
+    capistrano-passenger (0.0.5)
       capistrano (~> 3.0)
     capistrano-rails (1.1.6)
       capistrano (~> 3.1)
@@ -485,7 +485,7 @@ DEPENDENCIES
   binding_of_caller
   bond
   capistrano (~> 3.4.0)
-  capistrano-passenger
+  capistrano-passenger (= 0.0.5)
   capistrano-rails
   capistrano-rvm
   capistrano-sidekiq


### PR DESCRIPTION
Version 3.2.x is incompatible with rake 11. See http://stackoverflow.com/questions/36125870/nomethoderror-undefined-method-on-for-mainobject
