### PR TITLE
Improve matching of international student groups

### DIFF
--- a/app/models/import_options.rb
+++ b/app/models/import_options.rb
@@ -26,7 +26,7 @@ class ImportOptions < ActiveRecord::Base
   after_initialize do
     self.matching_groups            ||= :first_match
     self.tutorial_groups_regexp     ||= '\A(?<tutorial>T[\d]+)\z'
-    self.student_groups_regexp      ||= '\AG(?<tutorial>[\d]+)-(?<student>[\d]+)\z'
+    self.student_groups_regexp      ||= '\AG(?<tutorial>[\d]+)-(?<student>[\d]+)i?\z'
     self.column_separator           ||= ';'
     self.quote_char                 ||= '"'
     self.decimal_separator          ||= ','


### PR DESCRIPTION
Keith adds an additional `i` at the end of international student group names which breaks our importer using the default options.