### PR TITLE
Achievable points shown in reviews

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -124,7 +124,7 @@ class Exercise < ActiveRecord::Base
   end
 
   def achievable_points
-    visible_points.presence || (enable_max_total_points ? max_total_points : points)
+    visible_points.presence || (enable_max_total_points ? max_total_points : starting_points_sum)
   end
 
   def recalculate_term_registrations_results


### PR DESCRIPTION
Achievable points shown in reviews added maximum points defined in the exercises rating groups point ranges. This differs from the achievable points shown in the courses website. 

This changes the achievable points of Exercise to exclude the above mentioned maximum points.