### PR TITLE
Improve option names of variable points ratings

### DIFF
--- a/app/assets/javascripts/ratings.js.coffee
+++ b/app/assets/javascripts/ratings.js.coffee
@@ -50,15 +50,15 @@ update_fields_visibility = (form) ->
       min_field.show()
       max_field.show()
       multiplication_factor_field.hide()
-      min_label.text "Minimum Value (points)"
-      max_label.text "Maximum Value (points)"
+      min_label.text "Minimum Points"
+      max_label.text "Maximum Points"
     when "Ratings::VariableBonusPointsRating"
       value_field.hide()
       min_field.show()
       max_field.show()
       multiplication_factor_field.hide()
-      min_label.text "Minimum Value (points)"
-      max_label.text "Maximum Value (points)"
+      min_label.text "Minimum Points"
+      max_label.text "Maximum Points"
     when "Ratings::VariablePercentageDeductionRating"
       value_field.hide()
       min_field.show()


### PR DESCRIPTION
Change the names of variable points rating options to be more in line with other options.

* `Minimum Value (points)` -> `Minimum Points`
* `Maximum Value (points)` -> `Maximum Points`