### PR TITLE
Render Term Modal for Non-Admin Lecturers

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -21,8 +21,8 @@
         <%= link_to "Add Course", new_course_path, remote: true, class: "small button", data: {"reveal-id" => "reveal_modal"} %>
       </div>
     </div>
-
-    <%= render 'application/reveal_modal' %>
   <% end %>
+
+  <%= render 'application/reveal_modal' %>
 </div>
 


### PR DESCRIPTION
Render reveal modal in courses#index regardless of permissions. Non-Admin Lecturers were previously not able to create terms.