### PR TITLE
Busy Indication

### DIFF
--- a/app/assets/javascripts/components/loading_spinner.coffee
+++ b/app/assets/javascripts/components/loading_spinner.coffee
@@ -1,0 +1,15 @@
+@LoadingSpinner =
+  spin: (ms=500)->
+    @spinner = setTimeout( (=> @add_spinner()), ms)
+    $(document).on 'page:load', =>
+      @remove_spinner()
+
+  spinner: null
+  add_spinner: ->
+    $('body').addClass('progress-cursor')
+  remove_spinner: ->
+    clearTimeout(@spinner)
+    $('body').removeClass('progress-cursor')
+
+$(document).on 'page:before-change', ->
+  LoadingSpinner.spin()

--- a/app/assets/stylesheets/layout_enhancements.scss
+++ b/app/assets/stylesheets/layout_enhancements.scss
@@ -104,6 +104,10 @@ i[class*="fi-"] {
   text-align: center;
 }
 
+body.progress-cursor * {
+	cursor: progress !important;
+}
+
 dl.sub-nav {
   dd {
    margin-left: 10px;


### PR DESCRIPTION
A slightly different approach to #455. 

This changes the cursor to `progress` after each `turbolinks:before-change` with a slight delay so that the user will be informed that the page is loading in the background.

Based on this [gist](https://gist.github.com/cpuguy83/5016442)