### PR TITLE
Travis CI Failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - DB=sqlite
   - DB=postgresql
 
+dist: trusty
+
 before_script:
   - set -eux;
     export PHANTOMJS_VERSION=2.1.1;


### PR DESCRIPTION
Travis has started to use Xenial as the default building environment. Apparently this causes the build to fail.

This PR specifies the distribution to be used as Trusty.

#461