### PR TITLE
Enable turbolinks progress bar

### DIFF
--- a/app/assets/javascripts/components/turbolinks_progress_bar.coffee
+++ b/app/assets/javascripts/components/turbolinks_progress_bar.coffee
@@ -1,0 +1,1 @@
+Turbolinks.enableProgressBar(true);


### PR DESCRIPTION
The progress bar seems to be enabled by default in Turbolinks v5. For versions 2.x we need to enable it manually. 

Source: https://github.com/turbolinks/turbolinks-classic#progress-bar

Fixes #455 