### PR TITLE
Dependencies for net-ssh and ed25519 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,9 @@ group :development do
   gem 'capistrano-rails'       # capistrano plugin for Rails
   gem 'capistrano-sidekiq'     # capistrano plugin for Sidekiq
   gem 'capistrano-passenger'   # capistrano plugin for Passenger
+
+  gem 'ed25519'                # enable ed25519 support for net-ssh
+  gem 'bcrypt_pbkdf'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       execjs
     awesome_print (1.6.1)
     bcrypt (3.1.13)
+    bcrypt_pbkdf (1.0.1)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -147,6 +148,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dropzonejs-rails (0.7.3)
       rails (> 3.1)
+    ed25519 (1.2.4)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -441,6 +443,7 @@ DEPENDENCIES
   active_record-annotate
   autoprefixer-rails
   awesome_print
+  bcrypt_pbkdf
   better_errors
   binding_of_caller
   bond
@@ -463,6 +466,7 @@ DEPENDENCIES
   database_cleaner
   devise (~> 4.0)
   dropzonejs-rails
+  ed25519
   email_validator
   exception_notification
   factory_girl_rails
@@ -524,4 +528,4 @@ DEPENDENCIES
   zurb-foundation (~> 4.3.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This adds gems for ed25519 needed for deploying with ed25519 ssh-keys.

The accompanying error asked for these gems to be added to the bundler, solely installing the did not suffice. A related [issue](https://github.com/net-ssh/net-ssh/issues/478).