### PR TITLE
Add HomeIcon to Submission Tree Breadcrumbs

### DIFF
--- a/app/views/submission_tree/_submission_tree_path.html.erb
+++ b/app/views/submission_tree/_submission_tree_path.html.erb
@@ -2,7 +2,10 @@
   <ul class='breadcrumbs tree-path'>
     <% directory.parents.each.with_index do |entry, index| %>
       <%= content_tag :li, class: "#{"current" if index + 1 == directory.parents.length}" do %>
-        <%= link_to index == 0 ? foundation_icon(:home).html_safe  + " " + entry.name : entry.name, tree_submission_path(submission, path: entry.path_without_root) %>
+        <%= link_to tree_submission_path(submission, path: entry.path_without_root) do %>
+          <%= foundation_icon(:home) if index == 0 %>
+          <%= entry.name %>
+        <% end %>
       <% end %>
     <% end %>
   </ul>


### PR DESCRIPTION
When starting with an empty submission, it is not really clear that there is a breadcrumb path for the submission folder. Currently, with an empty submission is just states: 

`submission`

which is clickable and directs to the root of the submission, but only after adding, and navigation into, another folder, one can clearly identify the breadcrumbs:

`submission / someFolder`

where submission is then rendered as blue, underlined link. 

We have discussed some alternatives, where this PR currently includes what we have decided on. Although I'm quite sure that there is a more elegant way to prepend that home icon....