### PR TITLE
Submitter ID Backfill

### DIFF
--- a/db/migrate/20190411094443_add_submitter_id_to_submission_asset.rb
+++ b/db/migrate/20190411094443_add_submitter_id_to_submission_asset.rb
@@ -7,7 +7,7 @@ class AddSubmitterIdToSubmissionAsset < ActiveRecord::Migration
       if submission.submitter_id.present?
         submission.submission_assets.update_all(submitter_id: submission.submitter_id)
       elsif submission.exercise_registrations.first.present?
-        submission.submission_assets.update_all(submitter_id: submission.exercise_registrations.first)
+        submission.submission_assets.update_all(submitter_id: submission.exercise_registrations.first.term_registration.account)
       end
     end
 


### PR DESCRIPTION
This migration used the `exercise_registration_id` as backfill for the `submitter_id` of an asset. We need to use the `exercise_registrations`'s account id rather than the `exercise_registration_id` itself.