### PR TITLE
Delete Assets Which do not belong to any Submission

### DIFF
--- a/db/migrate/20210224093733_delete_residual_assets.rb
+++ b/db/migrate/20210224093733_delete_residual_assets.rb
@@ -1,0 +1,7 @@
+class DeleteResidualAssets < ActiveRecord::Migration
+  def change
+    SubmissionAsset.where.not(submission_id: Submission.select(:id)).each do |sa|
+      sa.destroy
+    end
+  end
+end


### PR DESCRIPTION
Adds a migration for deletion of the described assets.

This is related to #448 and #480. When deploying to production the residual assets caused some issues with this callback: `after_destroy :remove_from_submission_filesize`. In addition this is somewhat of a completion of the backfill introduced in #480 (which has been fixed in #512).