### PR TITLE
Destroy Submissions on Exercise Destroy

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -38,7 +38,7 @@ class Exercise < ActiveRecord::Base
   has_many :result_publications, dependent: :destroy
   has_many :rating_groups, dependent: :destroy
   has_many :attempts, dependent: :destroy, class_name: "ExerciseAttempt", inverse_of: :exercise
-  has_many :submissions
+  has_many :submissions, dependent: :destroy
 
   has_many :submission_evaluations, through: :submissions
   has_many :ratings, through: :rating_groups


### PR DESCRIPTION
We currently tell the user that on the destruction of a term, all submissions get deleted as well:

"Deleting a Term deletes all associated exercises, tutorial groups and **submissions** as well.",

but we actually don't do that.