### PR TITLE
Check for presence of full path

### DIFF
--- a/app/assets/javascripts/components/submission_upload_form.coffee
+++ b/app/assets/javascripts/components/submission_upload_form.coffee
@@ -116,7 +116,10 @@ class SubmissionUploadFormController
       init: ->
         @on 'addedfile', (file) ->
           $preview_container.show()
-          $(file.previewElement).find("*[data-dz-name]").text(file.fullPath)
+
+          if file.fullPath and file.fullPath != ""
+            $(file.previewElement).find("*[data-dz-name]").text(file.fullPath)
+
           $(file.previewElement).find(".status").hide()
           $(file.previewElement).find(".status-progress").show()
           that.needs_reload = true


### PR DESCRIPTION
Followup to #522 

This PR checks for the presence of `.fullPath` before overwriting the name placeholder. 
This PR is a quick fix, to prevent view inconsistencies in production. 


