### PR TITLE
Remove validation from save call

### DIFF
--- a/app/models/submission_asset.rb
+++ b/app/models/submission_asset.rb
@@ -195,7 +195,7 @@ class SubmissionAsset < ActiveRecord::Base
 
   def remove_from_submission_filesize
     submission.decrement(:filesystem_size, filesystem_size)
-    submission.save!
+    submission.save!(validate: false)
   end
 
   private


### PR DESCRIPTION
This PR should solve the issue #521. I've gone with not validating at all when the submission asset is destroyed for now.