### PR TITLE
Update Grading Scales on Term Max Points Update

### DIFF
--- a/app/models/grading_scale.rb
+++ b/app/models/grading_scale.rb
@@ -28,6 +28,13 @@ class GradingScale < ActiveRecord::Base
   scope :for_grade, lambda { |grade| find_by(grade: grade) }
   scope :grades, lambda { where(not_graded: false) }
 
+  def update_max_points(new_max_points)
+    if new_max_points != 0
+      self.max_points = new_max_points
+      self.save!
+    end
+  end
+
   private
 
   def validate_point_range

--- a/app/models/term.rb
+++ b/app/models/term.rb
@@ -56,6 +56,7 @@ class Term < ActiveRecord::Base
 
   def update_points!
     self.points = exercises.pluck(:points).compact.sum || 0
+    grading_scales.order("max_points DESC").limit(1).first.update_max_points(self.points)
     self.save!
   end
 


### PR DESCRIPTION
On production we're currently facing the issue that updating the maximum points achievable for that term, doesn't update the grading scale accordingly.
For example, increasing a term's maximum points, doesn't allow for the grading scale to go above the previous maximum points.

The current changes resolve the issue described above, but lowering the term's maximum points results in not being able to move the grading scales which are above the new value, e.g. term's max points goes from 100 to 50 -> grading scales with minimum points above 50 are not movable anymore.

Updating the grading scales correctly should resolve all issues where they're displayed, namely in the Points Overview and in Grading Scale  (Issue #526).