### PR TITLE
Bump rails to 4.11.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '=4.2.11.3'
 
-gem 'pg'                          # PostgreSQL database connector
+gem 'pg', "~>0.15"                          # PostgreSQL database connector
 
 gem 'jquery-rails'                # Use jquery as the JavaScript library
 gem 'jquery-ui-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
       parallel
     parser (2.7.0.4)
       ast (~> 2.4.0)
-    pg (1.2.3)
+    pg (0.21.0)
     poltergeist (1.16.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -500,7 +500,7 @@ DEPENDENCIES
   nntp-client!
   nokogiri
   parallel_tests
-  pg
+  pg (~> 0.15)
   poltergeist
   pry
   pry-byebug


### PR DESCRIPTION
Additional changes:
* No longer use `thin` in development (maybe we should switch to `puma`, if we want to implement real-time features)
* Bump `mysql2` and `pg` gems to work with the latest database versions (MySQL 8 and Postgres 13)