### PR TITLE
Add foreman for development service management

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'd3-rails', "~> 4.13.0"
 
 gem 'simple_form', '~> 3.0'       # forms
 gem 'devise',      '~> 4.0'       # user authentication
-# gem 'squeel',      '~> 1.2'       # easy DSL
 gem 'carrierwave'                 # fileuploads
 gem 'kaminari'                    # pagination
 gem 'pundit'                      # authorization based on controller actions and policies
@@ -78,9 +77,7 @@ group :development, :test do
 end
 
 group :development do
-  gem 'spring'                    # application preloader for development environments
-  gem 'spring-commands-rspec'     # adding rspec command to spring
-  gem 'spring-commands-sidekiq'   # adding sidekiq command to spring
+  gem 'foreman'
 
   gem 'active_record-annotate'    # adds the corresponding schema.rb snippet to each model file
   gem 'puma'                # small development webserver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/matthee/Sapphire-NNTP.git
+  remote: https://github.com/matthee/Sapphire-NNTP.git
   revision: 4508c2798688623cbccdecbea61b3ec46de3bd15
   specs:
     nntp-client (0.0.2)
@@ -159,6 +159,7 @@ GEM
     faker (2.18.0)
       i18n (>= 1.6, < 2)
     ffi (1.15.3)
+    foreman (0.87.2)
     foundation-icons-sass-rails (3.0.0)
       railties (>= 3.1.1)
       sass-rails (>= 3.1.1)
@@ -400,11 +401,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
-    spring (2.1.1)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
-    spring-commands-sidekiq (1.0.0)
-      spring (>= 0.9.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -482,6 +478,7 @@ DEPENDENCIES
   exception_notification
   factory_bot_rails
   faker
+  foreman
   foundation-icons-sass-rails (~> 3.0)
   jbuilder
   jist
@@ -525,9 +522,6 @@ DEPENDENCIES
   sidekiq (~> 5.2.3)
   simple_form (~> 3.0)
   simplecov
-  spring
-  spring-commands-rspec
-  spring-commands-sidekiq
   sqlite3 (~> 1.3.0)
   timecop
   traceroute
@@ -537,4 +531,4 @@ DEPENDENCIES
   writeexcel
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server
+sidekiq: bundle exec sidekiq


### PR DESCRIPTION
Allows developers to spin up the development environment more easily with a simple `foreman start` command.