### PR TITLE
Remove newproduction deployment config

### DIFF
--- a/config/deploy/new_production.rb
+++ b/config/deploy/new_production.rb
@@ -1,3 +1,0 @@
-set :rails_env, "production"
-
-server 'newsapphire.isds.tugraz.at', user: 'sapphire', roles: %w{app db web}


### PR DESCRIPTION
We are finished migrating to new production. Therefore we no longer need the new production deployment config.