### PR TITLE
Remove mysql2 dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :development, :test do
   gem 'bond'
   gem 'jist'
 
-  gem 'mysql2'                    # MySQL database connector
   gem 'sqlite3', "~>1.3.0"        # sqlite3 database connector
   gem 'parallel_tests'            # Parallelize Tests
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,6 @@ GEM
     msgpack (1.4.2)
     multi_logger (0.2.0)
       railties
-    mysql2 (0.5.3)
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -492,7 +491,6 @@ DEPENDENCIES
   mail
   mechanize
   multi_logger
-  mysql2
   nntp-client!
   nokogiri
   parallel_tests


### PR DESCRIPTION
We are no longer supporting MySQL - there is no point in having that gem as development dependency