### PR TITLE
584  Implement drag and drop functionality for submission tree

### DIFF
--- a/app/assets/javascripts/submission_assets/moves.coffee
+++ b/app/assets/javascripts/submission_assets/moves.coffee
@@ -1,0 +1,90 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/
+# app/assets/javascripts/drag_and_drop.coffee
+
+registerDragAndDrop = ->
+  entryElements = document.querySelectorAll('.folder-entry, .file-entry');
+
+  for entryElement in entryElements
+    entryElement.addEventListener 'dragstart', dragStart
+    entryElement.addEventListener 'dragenter', dragEnter
+    entryElement.addEventListener 'dragover', dragOver
+    entryElement.addEventListener 'dragleave', dragLeave
+    entryElement.addEventListener 'drop', drop
+
+document.addEventListener 'DOMContentLoaded', ->
+  registerDragAndDrop()
+
+$(document).on 'page:load', ->
+  registerDragAndDrop()
+
+
+dragStart = (event) ->
+  console.log "dragStart function called"
+  event.dataTransfer.setData 'text/plain', event.target.id
+  console.log event
+
+dragOver = (event) ->
+  event.preventDefault()
+  console.log "dragOver function called"
+  targetElement = event.target.closest 'tr'
+  if targetElement.classList.contains 'folder-entry'
+    event.dataTransfer.dropEffect = 'move'
+    targetElement.classList.add 'over'
+
+
+dragEnter = (event) ->
+  console.log "dragEnter function called"
+  event.preventDefault()
+  @classList.add 'over'
+
+dragLeave = (event) ->
+  console.log "dragLeave function called"
+  @classList.remove 'over'
+
+drop = (event) ->
+  console.log "drop function calleddddddddddddddd"
+  event.preventDefault()
+  @classList.remove 'over'
+  sourceId = event.dataTransfer.getData 'text/plain'
+  sourceElement = document.getElementById sourceId
+  targetElement = event.target.closest 'tr'
+  targetPath = targetElement.id
+  submissionId = sourceElement.id
+
+  console.log targetElement
+
+  # Check if the source element is a folder
+  if targetElement.classList.contains 'folder-entry'
+    if sourceElement.classList.contains 'file-entry'
+      $.ajax
+        type: 'POST'
+        url: '/submission_assets/move'
+        data:
+          submission_asset_id: submissionId
+          target_path: targetPath
+        success: (data, textStatus, jqXHR) ->
+          if data.redirect_url
+            window.location.href = data.redirect_url
+          else
+            console.log "Folder moved successfully"
+        error: (jqXHR, textStatus, errorThrown) ->
+          console.log "Error moving folder: #{errorThrown}"
+
+# Get the element that is being dragged
+draggableElement = document.querySelector '.draggable'
+
+# Add the 'dragover' event listener to the window object
+window.addEventListener 'dragover', (e) ->
+# Check if the mouse is near the top or bottom of the window
+  windowHeight = window.innerHeight
+  mousePosition = e.clientY
+  scrollDistance = 20
+
+  if mousePosition < scrollDistance
+# Scroll up by 20 pixels
+    window.scrollBy 0, -20
+  else if mousePosition > (windowHeight - scrollDistance)
+# Scroll down by 20 pixels
+    window.scrollBy 0, 20

--- a/app/assets/javascripts/submission_assets/moves.coffee
+++ b/app/assets/javascripts/submission_assets/moves.coffee
@@ -54,7 +54,8 @@ drop = (event) ->
   submissionId = sourceElement.id
 
   console.log targetElement
-
+  console.log submissionId
+  console.log targetPath
   # Check if the source element is a folder
   if targetElement.classList.contains 'folder-entry'
     if sourceElement.classList.contains 'file-entry'
@@ -72,6 +73,21 @@ drop = (event) ->
         error: (jqXHR, textStatus, errorThrown) ->
           console.log "Error moving folder: #{errorThrown}"
 
+    if sourceElement.classList.contains 'folder-entry'
+      $.ajax
+        type: 'POST'
+        url: targetElement.baseURI + '/move'
+        data:
+          submission_id: targetElement.baseURI.match(/\/submissions\/(\d+)\//)[1]
+          submission_asset_id: submissionId
+          target_path: targetPath
+        success: (data, textStatus, jqXHR) ->
+          if data.redirect_url
+            window.location.href = data.redirect_url
+          else
+            console.log "Folder moved successfully"
+        error: (jqXHR, textStatus, errorThrown) ->
+          console.log "Error moving folder: #{errorThrown}"
 # Get the element that is being dragged
 draggableElement = document.querySelector '.draggable'
 

--- a/app/assets/stylesheets/submission_assets/moves.scss
+++ b/app/assets/stylesheets/submission_assets/moves.scss
@@ -1,0 +1,3 @@
+.folder-entry.over {
+  background-color: #d0d0d0;
+}

--- a/app/controllers/submission_assets/moves_controller.rb
+++ b/app/controllers/submission_assets/moves_controller.rb
@@ -1,0 +1,28 @@
+class SubmissionAssets::MovesController < ApplicationController
+  include EventSourcing
+  before_action :set_context
+
+  def move
+    authorize @submission_asset
+    current_path = @submission_asset.path
+    @submission_asset.path = params[:target_path]
+
+    if @submission_asset.save
+      flash[:notice] = "Successfully moved file '#{@submission_asset.filename}' to '#{params[:target_path]}'."
+      render json: { redirect_url: tree_submission_path(@submission_asset.submission, path: current_path) }, status: :ok
+    else
+      flash[:error] = "Failed to move file '#{@submission_asset.filename}'."
+      render json: { error: 'Failed to move file', redirect_url: tree_submission_path(@submission_asset.submission, path: current_path),  }, status: :ok
+    end
+  end
+
+
+  private
+
+  def set_context
+    @submission_asset = SubmissionAsset.find(params[:submission_asset_id])
+    @term = @submission_asset.submission.term
+    @submission = @submission_asset.submission
+  end
+
+end

--- a/app/controllers/submission_folder_moves_controller.rb
+++ b/app/controllers/submission_folder_moves_controller.rb
@@ -1,0 +1,65 @@
+require 'pathname'
+class SubmissionFolderMovesController < ApplicationController
+  include EventSourcing
+
+  before_action :set_context
+
+  def move
+    authorize @tree
+    source_path = Pathname.new(params[:submission_asset_id])
+    source_path_basename = File.basename(source_path)
+
+    target_path = Pathname.new(params[:target_path])
+    target_path_basename = File.basename(target_path)
+
+    new_directory_path = target_path.join(source_path_basename)
+
+    if source_path == target_path then # moving folder to itself
+      #flash[:error] = "Failed to move folder '#{source_basename}': A folder named '#{source_basename}' already exist in '#{target_last_segment}'."
+      #render json: { error: 'Failed to move file', redirect_url: tree_submission_path(@submission, path:  @directory.parent.try(:path_without_root)),  }, status: :ok
+      return
+    end
+
+    submission_assets = @submission.submission_assets.where(path: source_path.to_s).
+      or(@submission.submission_assets.where("path like ?", "#{source_path.to_s}/%"))
+
+    # moving folder to a folder where a folder with the same name already exist
+    if @tree.resolve(new_directory_path).entries.any?
+      flash[:error] = "Failed to move folder '#{source_path_basename}': A folder named '#{source_path_basename}' already exist in '#{target_path}'."
+      render json: { error: 'Failed to move file', redirect_url: tree_submission_path(@submission, path:  @directory.parent.try(:path_without_root)),  }, status: :ok
+      return
+    end
+
+    submission_assets.each do |asset|
+      asset_path = Pathname.new(asset.path)
+      relative_asset_path = asset_path.relative_path_from(source_path)
+      new_asset_path = new_directory_path.join(relative_asset_path)
+      asset.path = new_asset_path
+    end
+
+    success = submission_assets.all? do |asset|
+      asset.valid? && asset.save
+    end
+
+    if success
+      flash[:notice] = "Successfully moved file '#{source_path_basename.to_s}' to #{ target_path_basename.to_s.empty? ? 'root directory' : "''" + target_path.to_s + "''"}."
+      render json: { redirect_url: tree_submission_path(@submission, path: @directory.parent.path_without_root) }, status: :ok
+    else
+      flash[:error] = "Failed to move file '#{source_path}'."
+      render json: { error: 'Failed to move file', redirect_url: tree_submission_path(@submission, path:  @directory.parent.try(:path_without_root)),  }, status: :ok
+    end
+  end
+
+
+  private
+
+  def set_context
+    @submission = Submission.find(params[:submission_id])
+    @tree = @submission.tree
+    print(params[:submission_asset_id])
+    @directory = @tree.resolve(params[:submission_asset_id])
+  rescue SubmissionStructure::FileNotFound
+    raise ActiveRecord::RecordNotFound
+  end
+
+end

--- a/app/policies/submission_asset_policy.rb
+++ b/app/policies/submission_asset_policy.rb
@@ -9,6 +9,11 @@ class SubmissionAssetPolicy < TermBasedPolicy
     modifiable?
   end
 
+  def move?
+    staff_permissions?(record.submission.exercise.term) ||
+      modifiable?
+  end
+
   private
   def modifiable?
     submission = record.submission

--- a/app/policies/submission_structure/tree_policy.rb
+++ b/app/policies/submission_structure/tree_policy.rb
@@ -7,6 +7,10 @@ class SubmissionStructure::TreePolicy < TermBasedPolicy
     show?
   end
 
+  def move?
+    write_permissions?
+  end
+
   def destroy?
     write_permissions?
   end

--- a/app/views/submission_tree/_submission_directory.html.erb
+++ b/app/views/submission_tree/_submission_directory.html.erb
@@ -49,7 +49,7 @@
               <% end %>
             <% end %>
           <% else %>
-            <%= link_to entry.name, tree_submission_path(submission, path: entry.path_without_root) %>
+            <%= link_to entry.name, tree_submission_path(submission, path: entry.path_without_root),  draggable: false%>
           <% end %>
         </td>
         <td class='modification-date' data-sort="<%= entry.mtime %>" data-sort-as="integer"><%= submission_tree_modification_date(entry.mtime) %></td>

--- a/app/views/submission_tree/_submission_directory.html.erb
+++ b/app/views/submission_tree/_submission_directory.html.erb
@@ -14,7 +14,10 @@
   </thead>
   <tbody>
     <% unless directory.root? %>
-      <tr data-sort-top="true">
+      <tr data-sort-top="true"
+          id="<%= directory.parent.path_without_root %>"
+          class='folder-entry'
+      >
         <td class='icon'></td>
         <td>
           <%= link_to "..", tree_submission_path(submission, path: directory.parent.path_without_root), title: "Goto parent folder" %>
@@ -29,13 +32,16 @@
     <% end %>
 
     <% directory.entries.sort_by(&:name).each do |entry| %>
-      <tr>
-        <td class='icon'>
+    <tr data-sort-top="true" draggable="true"
+        id="<%= entry.directory? ? entry.path_without_root : entry.submission_asset.id %>"
+        class="<%= entry.directory? ? 'folder-entry' : 'file-entry' %>"
+    >
+    <td class='icon'>
           <%= foundation_icon entry.icon %>
         </td>
         <td>
           <% if entry.file? %>
-            <%= link_to entry.name, submission_asset_path(entry.submission_asset), target: "_blank" %>
+            <%= link_to entry.name, submission_asset_path(entry.submission_asset), target: "_blank", draggable: false %>
             <% if entry.submission_asset.archive? %>
               &mdash; Extraction: <%= submission_asset_extraction_status(entry.submission_asset) %>
               <% if entry.submission_asset.extraction_failed? %>
@@ -56,9 +62,9 @@
         <% if submission.modifiable_by_students? %>
           <td class='buttons'>
             <% if entry.file? %>
-              <%= link_to foundation_icon(:x), submission_asset_path(entry.submission_asset), method: :delete, data: {confirm: "Are you sure, that you want to remove this file?"}, class: "tiny alert button" %>
+              <%= link_to foundation_icon(:x), submission_asset_path(entry.submission_asset), method: :delete, data: {confirm: "Are you sure, that you want to remove this file?"}, class: "tiny alert button", draggable: false %>
             <% else %>
-              <%= link_to foundation_icon(:x), tree_submission_path(submission, path: entry.path_without_root), method: :delete, data: {confirm: "Are you sure, that you want to remove the whole directory?"}, class: "tiny alert button" %>
+              <%= link_to foundation_icon(:x), tree_submission_path(submission, path: entry.path_without_root), method: :delete, data: {confirm: "Are you sure, that you want to remove the whole directory?"}, class: "tiny alert button", draggable: false %>
             <% end %>
           </td>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,8 @@ Rails.application.routes.draw do
   resources :submission_assets, only: [:show, :destroy]
   resources :submission_viewers, only: [:show]
 
+  post 'submission_assets/move' => 'submission_assets/moves#move'
+
   resources :evaluations, only: :update do
     resources :explanations, module: :evaluations
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
       get "tree(/*path)", controller: :submission_tree, action: :show, as: :tree
       get "directory(/*path)", controller: :submission_tree, action: :directory, as: :tree_directory
       delete "tree(/*path)", controller: :submission_tree, action: :destroy
+      post "tree(/*path)/move", controller: :submission_folder_moves, action: :move
     end
     resources :students, controller: "submissions/students"
     resource :folder, controller: :submission_folders, only: [:show, :new, :create]


### PR DESCRIPTION
This pull request adds drag and drop functionality for files and folders in the submission tree. 
Users can now drag and drop files and folders to move them around the tree. It fixes issue #584 

I still need to add the event/service and RSpecs, but I have not done so yet since I may need to refactor the code after receiving feedback. I have created a branch with the implementation, which you can find at the following link: 

https://github.com/Sapphire-CM/Sapphire/tree/584-drag-drop-files-submission-tree-view

Please let me know if you have any feedback or if you need me to make any changes.

Thanks for your time and consideration.
