### PR TITLE
Remove extraction of ZIP-archives for submissions

### DIFF
--- a/app/models/submission_asset.rb
+++ b/app/models/submission_asset.rb
@@ -185,7 +185,7 @@ class SubmissionAsset < ActiveRecord::Base
   end
 
   def archive?
-    Mime::ARCHIVES.include? self.content_type
+    false # Mime::ARCHIVES.include? self.content_type
   end
 
   def add_to_submission_filesize

--- a/app/models/submission_upload.rb
+++ b/app/models/submission_upload.rb
@@ -41,7 +41,7 @@ class SubmissionUpload
   end
 
   def archive_upload?
-    submission_asset.content_type == SubmissionAsset::Mime::ZIP
+    false # submission_asset.content_type == SubmissionAsset::Mime::ZIP
   end
 
   def schedule_extraction!


### PR DESCRIPTION
This PR is linked to issue [563](https://github.com/Sapphire-CM/Sapphire/issues/563#issue-1177080179).
The code from this branch is deployed on production since last year.

Keith does not want automatic extraction of archives happening on Sapphire.
Either users should be able to extract using a option that is available through a context menu when right-clicking the archive or the extraction functionality should be removed entirely.

Of course the current code is not very nice and instead I would remove the entirety of the extraction functionality if you (@matthee) are OK with it?