### PR TITLE
Remove results tab when results not published yet

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -134,6 +134,10 @@ class Exercise < ActiveRecord::Base
     rating_groups.sum(:points)
   end
 
+  def results_published_for_account?(current_account)
+    Submission.active.for_account(current_account).for_exercise(self).first.try(:result_published?)
+  end
+
   private
   def ensure_result_publications
     term.tutorial_groups.each do |tutorial_group|

--- a/app/views/exercises/_subnav.html.erb
+++ b/app/views/exercises/_subnav.html.erb
@@ -7,7 +7,7 @@
   <%= subnav_item(:widget, "Services", term_exercise_services_path(exercise.term, exercise), params[:controller] == "services")  if policy(ServicePolicy.term_policy_record(exercise.term)).index? %>
 
   <%= subnav_item(:list, "Submission", exercise_student_submission_path(exercise), params[:controller] == "submissions" || params[:controller] == "submission_tree") if current_account.student_of_term?(exercise.term) %>
-  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? %>
+  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? && GradingReview::SubmissionReview.find_by_account_and_exercise(current_account, exercise).published? %>
 
   <%= subnav_item(:pencil, "Administrate", edit_exercise_path(exercise), params[:controller] == "exercises" && params[:action] == "edit") if policy(exercise).edit? %>
 </dl>

--- a/app/views/exercises/_subnav.html.erb
+++ b/app/views/exercises/_subnav.html.erb
@@ -7,7 +7,7 @@
   <%= subnav_item(:widget, "Services", term_exercise_services_path(exercise.term, exercise), params[:controller] == "services")  if policy(ServicePolicy.term_policy_record(exercise.term)).index? %>
 
   <%= subnav_item(:list, "Submission", exercise_student_submission_path(exercise), params[:controller] == "submissions" || params[:controller] == "submission_tree") if current_account.student_of_term?(exercise.term) %>
-  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? && Submission.active.for_account(current_account).for_exercise(exercise).first.try(:result_published?) %>
+  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? && exercise.results_published_for_account?(current_account) %>
 
   <%= subnav_item(:pencil, "Administrate", edit_exercise_path(exercise), params[:controller] == "exercises" && params[:action] == "edit") if policy(exercise).edit? %>
 </dl>

--- a/app/views/exercises/_subnav.html.erb
+++ b/app/views/exercises/_subnav.html.erb
@@ -7,7 +7,7 @@
   <%= subnav_item(:widget, "Services", term_exercise_services_path(exercise.term, exercise), params[:controller] == "services")  if policy(ServicePolicy.term_policy_record(exercise.term)).index? %>
 
   <%= subnav_item(:list, "Submission", exercise_student_submission_path(exercise), params[:controller] == "submissions" || params[:controller] == "submission_tree") if current_account.student_of_term?(exercise.term) %>
-  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? && GradingReview::SubmissionReview.find_by_account_and_exercise(current_account, exercise).published? %>
+  <%= subnav_item(:megaphone, "Results", term_result_path(exercise.term, exercise), params[:controller] == "student_results") if policy(StudentResultsPolicy.term_policy_record(exercise.term)).index? && Submission.active.for_account(current_account).for_exercise(exercise).first.try(:result_published?) %>
 
   <%= subnav_item(:pencil, "Administrate", edit_exercise_path(exercise), params[:controller] == "exercises" && params[:action] == "edit") if policy(exercise).edit? %>
 </dl>

--- a/spec/features/course_management/behaviours/exercise_sub_navigation_behaviour.rb
+++ b/spec/features/course_management/behaviours/exercise_sub_navigation_behaviour.rb
@@ -49,15 +49,89 @@ RSpec.shared_examples "Exercise Sub Navigation" do |roles|
   end
 
   if roles.include?(:student)
-    context 'as student' do
+    context 'as student with submission' do
       let(:term_registration) { FactoryBot.create(:term_registration, :student, term: exercise.term) }
+      let(:submission) { FactoryBot.create(:submission, exercise: exercise, submitter: account) }
+      let(:result_publication) { ResultPublication.where(exercise: exercise, tutorial_group_id: term_registration.tutorial_group).first }
+      let!(:exercise_registration) { FactoryBot.create(:exercise_registration, exercise: exercise, term_registration: term_registration, submission: submission) }
 
-      scenario "Provides sub navigation links" do
+      scenario "Provides sub navigation links with published results" do
+        expect(result_publication.concealed?).to be_truthy
+
+        result_publication.publish!
+
         visit base_path
+
+        expect(result_publication.published?).to be_truthy
 
         within ".sub-nav" do
           expect(page).to have_link("Exercise", href: exercise_path(exercise))
+          expect(page).to have_text("Submission")
+          expect(page).to have_text("Results")
 
+          expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
+          expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
+          expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))
+          expect(page).not_to have_link("Services", href: term_exercise_services_path(exercise.term, exercise))
+          expect(page).not_to have_link("Administrate", href: edit_exercise_path(exercise))
+        end
+      end
+
+      scenario "Provides sub navigation links without published results" do
+        visit base_path
+
+        expect(result_publication.concealed?).to be_truthy
+
+        within ".sub-nav" do
+          expect(page).to have_link("Exercise", href: exercise_path(exercise))
+          expect(page).to have_text("Submission")
+
+          expect(page).not_to have_text("Results")
+          expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
+          expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
+          expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))
+          expect(page).not_to have_link("Services", href: term_exercise_services_path(exercise.term, exercise))
+          expect(page).not_to have_link("Administrate", href: edit_exercise_path(exercise))
+        end
+      end
+    end
+
+    context 'as student without submission' do
+      let(:term_registration) { FactoryBot.create(:term_registration, :student, term: exercise.term) }
+      let(:result_publication) { ResultPublication.where(exercise: exercise, tutorial_group_id: term_registration.tutorial_group).first }
+
+      scenario "Provides sub navigation links with published results" do
+        expect(result_publication.concealed?).to be_truthy
+
+        result_publication.publish!
+
+        visit base_path
+
+        expect(result_publication.published?).to be_truthy
+
+        within ".sub-nav" do
+          expect(page).to have_link("Exercise", href: exercise_path(exercise))
+          expect(page).to have_text("Submission")
+
+          expect(page).not_to have_text("Results")
+          expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
+          expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
+          expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))
+          expect(page).not_to have_link("Services", href: term_exercise_services_path(exercise.term, exercise))
+          expect(page).not_to have_link("Administrate", href: edit_exercise_path(exercise))
+        end
+      end
+
+      scenario "Provides sub navigation links without published results" do
+        visit base_path
+
+        expect(result_publication.concealed?).to be_truthy
+
+        within ".sub-nav" do
+          expect(page).to have_link("Exercise", href: exercise_path(exercise))
+          expect(page).to have_text("Submission")
+
+          expect(page).not_to have_text("Results")
           expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
           expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
           expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))

--- a/spec/features/course_management/behaviours/exercise_sub_navigation_behaviour.rb
+++ b/spec/features/course_management/behaviours/exercise_sub_navigation_behaviour.rb
@@ -66,8 +66,8 @@ RSpec.shared_examples "Exercise Sub Navigation" do |roles|
 
         within ".sub-nav" do
           expect(page).to have_link("Exercise", href: exercise_path(exercise))
-          expect(page).to have_text("Submission")
-          expect(page).to have_text("Results")
+          expect(page).to have_link("Submission", href: exercise_student_submission_path(exercise))
+          expect(page).to have_link("Results", href: term_result_path(exercise.term, exercise))
 
           expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
           expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
@@ -84,9 +84,9 @@ RSpec.shared_examples "Exercise Sub Navigation" do |roles|
 
         within ".sub-nav" do
           expect(page).to have_link("Exercise", href: exercise_path(exercise))
-          expect(page).to have_text("Submission")
+          expect(page).to have_link("Submission", href: exercise_student_submission_path(exercise))
 
-          expect(page).not_to have_text("Results")
+          expect(page).not_to have_link("Results", href: term_result_path(exercise.term, exercise))
           expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
           expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
           expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))
@@ -111,9 +111,9 @@ RSpec.shared_examples "Exercise Sub Navigation" do |roles|
 
         within ".sub-nav" do
           expect(page).to have_link("Exercise", href: exercise_path(exercise))
-          expect(page).to have_text("Submission")
+          expect(page).to have_link("Submission", href: exercise_student_submission_path(exercise))
 
-          expect(page).not_to have_text("Results")
+          expect(page).not_to have_link("Results", href: term_result_path(exercise.term, exercise))
           expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
           expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
           expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))
@@ -129,9 +129,9 @@ RSpec.shared_examples "Exercise Sub Navigation" do |roles|
 
         within ".sub-nav" do
           expect(page).to have_link("Exercise", href: exercise_path(exercise))
-          expect(page).to have_text("Submission")
+          expect(page).to have_link("Submission", href: exercise_student_submission_path(exercise))
 
-          expect(page).not_to have_text("Results")
+          expect(page).not_to have_link("Results", href: term_result_path(exercise.term, exercise))
           expect(page).not_to have_link("Ratings", href: exercise_rating_groups_path(exercise))
           expect(page).not_to have_link("Submissions", href: exercise_submissions_path(exercise))
           expect(page).not_to have_link("Publish Results", href: exercise_result_publications_path(exercise))


### PR DESCRIPTION
This fixes the issue #608.

I'm not sure if this is the correct way to do this. Any input @matthee?